### PR TITLE
Slight adjustments to 'Next' buttons in Create Account

### DIFF
--- a/packages/edge-login-ui-rn/src/native/components/screens/newAccount/NewAccountReviewScreenComponent.js
+++ b/packages/edge-login-ui-rn/src/native/components/screens/newAccount/NewAccountReviewScreenComponent.js
@@ -48,7 +48,7 @@ export default class NewAccountReviewScreenComponent extends Component<Props> {
               }
               upStyle={NewAccountReviewScreenStyle.nextButton.upStyle}
               upTextStyle={NewAccountReviewScreenStyle.nextButton.upTextStyle}
-              label={s.strings.done}
+              label={s.strings.next_label}
             />
           </View>
         </View>

--- a/packages/edge-login-ui-rn/src/native/components/screens/newAccount/NewAccountUsernameScreenComponent.js
+++ b/packages/edge-login-ui-rn/src/native/components/screens/newAccount/NewAccountUsernameScreenComponent.js
@@ -56,7 +56,7 @@ export default class LandingScreenComponent extends Component<Props, State> {
               }
               upStyle={NewAccountUsernameScreenStyle.nextButton.upStyle}
               upTextStyle={NewAccountUsernameScreenStyle.nextButton.upTextStyle}
-              label={s.strings.next_label_caps}
+              label={s.strings.next_label}
               isThinking={this.state.isProcessing}
               doesThink
             />

--- a/packages/edge-login-ui-rn/src/native/components/screens/newAccount/SetAccountPinScreenComponent.js
+++ b/packages/edge-login-ui-rn/src/native/components/screens/newAccount/SetAccountPinScreenComponent.js
@@ -61,7 +61,7 @@ export default class SetAccountPinScreenComponent extends Component<
                 }
                 upStyle={SetAccountPinScreenStyle.nextButton.upStyle}
                 upTextStyle={SetAccountPinScreenStyle.nextButton.upTextStyle}
-                label={s.strings.next_label_caps}
+                label={s.strings.next_label}
                 isThinking={this.state.isProcessing}
                 doesThink
               />


### PR DESCRIPTION
The purpose of this task is to change the 'Done' button to 'Next' for account creation since there is still a Terms of Service scene / page next.

Asana Task: https://app.asana.com/0/361770107085503/588399275369074/f