### PR TITLE
check for OTP reset on all account on phone

### DIFF
--- a/packages/edge-login-ui-rn/src/common/locales/en_US.js
+++ b/packages/edge-login-ui-rn/src/common/locales/en_US.js
@@ -145,7 +145,7 @@ const strings = {
   account_locked_for: 'Account locked for \n%1$s more seconds',
   otp_modal_reset_headline: '2FA Reset Requested',
   otp_modal_reset_body:
-    'URGENT: 2FA reset has been requested by another device for the following accounts:\n %1$s\n\nIf you did not request a 2FA reset, please go to Settings -> 2 Factor and click Keep 2FA. Then change your password."'
+    'URGENT: 2FA reset has been requested by another device for the following accounts:\n %1$s\n\nIf you did not request a 2FA reset, please go to Settings -> 2 Factor and click Keep 2FA. Then change your password.'
 }
 
 module.exports = strings

--- a/packages/edge-login-ui-rn/src/common/locales/en_US.js
+++ b/packages/edge-login-ui-rn/src/common/locales/en_US.js
@@ -145,7 +145,7 @@ const strings = {
   account_locked_for: 'Account locked for \n%1$s more seconds',
   otp_modal_reset_headline: '2FA Reset Requested',
   otp_modal_reset_body:
-    '2FA disable has been requested by another device for the following accounts on this device:\n'
+    'URGENT: 2FA reset has been requested by another device for the following accounts:\n'
 }
 
 module.exports = strings

--- a/packages/edge-login-ui-rn/src/common/locales/en_US.js
+++ b/packages/edge-login-ui-rn/src/common/locales/en_US.js
@@ -142,7 +142,10 @@ const strings = {
   landing_already_have_account: 'Already have an account? Sign in',
   pin_not_enabled: 'PIN is not enabled for this account',
   invalid_pin: 'Invalid PIN',
-  account_locked_for: 'Account locked for \n%1$s more seconds'
+  account_locked_for: 'Account locked for \n%1$s more seconds',
+  otp_modal_reset_headline: '2FA Reset Requested',
+  otp_modal_reset_body:
+    '2FA disable has been requested by another device for the following accounts on this device:\n'
 }
 
 module.exports = strings

--- a/packages/edge-login-ui-rn/src/common/locales/en_US.js
+++ b/packages/edge-login-ui-rn/src/common/locales/en_US.js
@@ -145,7 +145,7 @@ const strings = {
   account_locked_for: 'Account locked for \n%1$s more seconds',
   otp_modal_reset_headline: '2FA Reset Requested',
   otp_modal_reset_body:
-    'URGENT: 2FA reset has been requested by another device for the following accounts:\n'
+    'URGENT: 2FA reset has been requested by another device for the following accounts:\n %1$s\n\nIf you did not request a 2FA reset, please go to Settings -> 2 Factor and click Keep 2FA. Then change your password."'
 }
 
 module.exports = strings

--- a/packages/edge-login-ui-rn/src/common/locales/strings/enUS.json
+++ b/packages/edge-login-ui-rn/src/common/locales/strings/enUS.json
@@ -117,5 +117,5 @@
   "invalid_pin": "Invalid PIN",
   "account_locked_for": "Account locked for \n%1$s more seconds",
   "otp_modal_reset_headline": "2FA Reset Requested",
-  "otp_modal_reset_body": "URGENT: 2FA reset has been requested by another device for the following accounts:\n %1$s\n\nIf you did not request a 2FA reset, please go to Settings -> 2 Factor and click Keep 2FA. Then change your password.\""
+  "otp_modal_reset_body": "URGENT: 2FA reset has been requested by another device for the following accounts:\n %1$s\n\nIf you did not request a 2FA reset, please go to Settings -> 2 Factor and click Keep 2FA. Then change your password."
 }

--- a/packages/edge-login-ui-rn/src/common/locales/strings/enUS.json
+++ b/packages/edge-login-ui-rn/src/common/locales/strings/enUS.json
@@ -117,5 +117,5 @@
   "invalid_pin": "Invalid PIN",
   "account_locked_for": "Account locked for \n%1$s more seconds",
   "otp_modal_reset_headline": "2FA Reset Requested",
-  "otp_modal_reset_body": "URGENT: 2FA reset has been requested by another device for the following accounts:\n"
+  "otp_modal_reset_body": "URGENT: 2FA reset has been requested by another device for the following accounts:\n %1$s\n\nIf you did not request a 2FA reset, please go to Settings -> 2 Factor and click Keep 2FA. Then change your password.\""
 }

--- a/packages/edge-login-ui-rn/src/common/locales/strings/enUS.json
+++ b/packages/edge-login-ui-rn/src/common/locales/strings/enUS.json
@@ -117,5 +117,5 @@
   "invalid_pin": "Invalid PIN",
   "account_locked_for": "Account locked for \n%1$s more seconds",
   "otp_modal_reset_headline": "2FA Reset Requested",
-  "otp_modal_reset_body": "2FA disable has been requested by another device for the following accounts on this device:\n"
+  "otp_modal_reset_body": "URGENT: 2FA reset has been requested by another device for the following accounts:\n"
 }

--- a/packages/edge-login-ui-rn/src/common/locales/strings/enUS.json
+++ b/packages/edge-login-ui-rn/src/common/locales/strings/enUS.json
@@ -115,5 +115,7 @@
   "landing_already_have_account": "Already have an account? Sign in",
   "pin_not_enabled": "PIN is not enabled for this account",
   "invalid_pin": "Invalid PIN",
-  "account_locked_for": "Account locked for \n%1$s more seconds"
+  "account_locked_for": "Account locked for \n%1$s more seconds",
+  "otp_modal_reset_headline": "2FA Reset Requested",
+  "otp_modal_reset_body": "2FA disable has been requested by another device for the following accounts on this device:\n"
 }

--- a/packages/edge-login-ui-rn/src/common/util/checkingForOTP.js
+++ b/packages/edge-login-ui-rn/src/common/util/checkingForOTP.js
@@ -16,8 +16,8 @@ const checkingForOTP = context => {
           arrayString = arrayString + (key + ', ')
         }
       }
-      arrayString = arrayString.slice(0, -2)
       if (accountsPendingReset.length > 0) {
+        arrayString = arrayString.slice(0, -2)
         Alert.alert(
           s.strings.otp_modal_reset_headline,
           sprintf(s.strings.otp_modal_reset_body, arrayString)

--- a/packages/edge-login-ui-rn/src/common/util/checkingForOTP.js
+++ b/packages/edge-login-ui-rn/src/common/util/checkingForOTP.js
@@ -16,6 +16,7 @@ const checkingForOTP = context => {
           arrayString = arrayString + (key + ', ')
         }
       }
+      arrayString = arrayString.slice(0, -2)
       if (accountsPendingReset.length > 0) {
         Alert.alert(
           s.strings.otp_modal_reset_headline,

--- a/packages/edge-login-ui-rn/src/common/util/checkingForOTP.js
+++ b/packages/edge-login-ui-rn/src/common/util/checkingForOTP.js
@@ -1,0 +1,31 @@
+import { Alert } from 'react-native'
+
+import s from '../locales/strings.js'
+
+const checkingForOTP = context => {
+  const accountsPendingReset = []
+  let arrayString = ''
+  context
+    .fetchLoginMessages()
+    .then(async accounts => {
+      for (const key in accounts) {
+        const account = accounts[key]
+        if (account.otpResetPending) {
+          accountsPendingReset.push(key)
+          arrayString = arrayString + (key + '\n')
+        }
+      }
+      if (accountsPendingReset.length > 0) {
+        Alert.alert(
+          s.strings.otp_modal_reset_headline,
+          s.strings.otp_modal_reset_body + arrayString
+        )
+      }
+    })
+    .catch(e => {
+      console.log('CH: error', e)
+      return {}
+    })
+}
+
+export { checkingForOTP }

--- a/packages/edge-login-ui-rn/src/common/util/checkingForOTP.js
+++ b/packages/edge-login-ui-rn/src/common/util/checkingForOTP.js
@@ -12,7 +12,7 @@ const checkingForOTP = context => {
         const account = accounts[key]
         if (account.otpResetPending) {
           accountsPendingReset.push(key)
-          arrayString = arrayString + (key + '\n')
+          arrayString = arrayString + (key + ', ')
         }
       }
       if (accountsPendingReset.length > 0) {

--- a/packages/edge-login-ui-rn/src/common/util/checkingForOTP.js
+++ b/packages/edge-login-ui-rn/src/common/util/checkingForOTP.js
@@ -1,4 +1,5 @@
 import { Alert } from 'react-native'
+import { sprintf } from 'sprintf-js'
 
 import s from '../locales/strings.js'
 
@@ -18,7 +19,7 @@ const checkingForOTP = context => {
       if (accountsPendingReset.length > 0) {
         Alert.alert(
           s.strings.otp_modal_reset_headline,
-          s.strings.otp_modal_reset_body + arrayString
+          sprintf(s.strings.otp_modal_reset_body, arrayString)
         )
       }
     })

--- a/packages/edge-login-ui-rn/src/native/components/exportAPIComponents/LoginScreen.js
+++ b/packages/edge-login-ui-rn/src/native/components/exportAPIComponents/LoginScreen.js
@@ -9,6 +9,7 @@ import thunk from 'redux-thunk'
 
 import { updateFontStyles } from '../../../common/constants/Fonts'
 import reducers from '../../../common/reducers'
+import { checkingForOTP } from '../../../common/util/checkingForOTP.js'
 import type { Imports } from '../../../types/ReduxTypes'
 import LoginAppConnector from '../../connectors/LogInAppConnector'
 import * as Styles from '../../styles'
@@ -35,6 +36,7 @@ class LoginScreen extends Component<Props> {
   }
 
   componentWillMount () {
+    checkingForOTP(this.props.context)
     updateFontStyles(this.props)
     const composeEnhancers =
       typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__


### PR DESCRIPTION
This moves checking for 2FA reset to login system and throws a system alert if any accounts on the phone have received a 2FA reset request from another device. 