### PR TITLE
Disable touchID button during / after logging in

### DIFF
--- a/packages/edge-login-ui-rn/src/native/components/common/ImageButton.js
+++ b/packages/edge-login-ui-rn/src/native/components/common/ImageButton.js
@@ -5,12 +5,16 @@ import { Image, TouchableWithoutFeedback, View } from 'react-native'
 type Props = {
   style: Object,
   source: string,
-  onPress(): void
+  onPress(): void,
+  disabled?: boolean
 }
 class ImageButton extends Component<Props> {
   render () {
     return (
-      <TouchableWithoutFeedback onPress={this.props.onPress}>
+      <TouchableWithoutFeedback
+        onPress={this.props.onPress}
+        disabled={this.props.disabled}
+      >
         <View style={this.props.style.container}>
           <Image source={this.props.source} style={this.props.style.image} />
         </View>

--- a/packages/edge-login-ui-rn/src/native/components/screens/PinLogInScreenComponent.js
+++ b/packages/edge-login-ui-rn/src/native/components/screens/PinLogInScreenComponent.js
@@ -22,7 +22,8 @@ type Props = {
   launchUserLoginWithTouchId(Object): void,
   changeUser(string): void,
   launchDeleteModal(): void,
-  gotoLoginPage(): void
+  gotoLoginPage(): void,
+  isTouchIdDisabled: boolean
 }
 type State = {
   loggingIn: boolean,
@@ -53,6 +54,7 @@ export default class PinLogInScreenComponent extends Component<Props, State> {
           style={style.thumbprintButton}
           source={Assets.TOUCH}
           onPress={this.relaunchTouchId}
+          disabled={this.props.isTouchIdDisabled}
         />
       )
     }

--- a/packages/edge-login-ui-rn/src/native/connectors/screens/PinLoginScreenConnector.js
+++ b/packages/edge-login-ui-rn/src/native/connectors/screens/PinLoginScreenConnector.js
@@ -8,15 +8,20 @@ import type { Dispatch, State } from '../../../types/ReduxTypes'
 import LinkedComponent from '../../components/screens/PinLogInScreenComponent'
 
 export const mapStateToProps = (state: State) => {
+  const pinLength = state.login.pin ? state.login.pin.length : 0
+  const loginSuccess = state.login.loginSuccess
+  const wait = state.login.wait
+  const isTouchIdDisabled =
+    loginSuccess || wait || state.login.isLoggingInWithPin || pinLength === 4
   return {
     username: state.login.username,
-    loginSuccess: state.login.loginSuccess,
+    loginSuccess,
     previousUsers: state.previousUsers.userList,
     usersWithPin: state.previousUsers.usersWithPinList,
     workflow: state.workflow,
     showModal: state.workflow.showModal,
-    isTouchIdDisabled:
-      state.login.isLoggingInWithPin || state.login.loginSuccess
+    wait,
+    isTouchIdDisabled
   }
 }
 

--- a/packages/edge-login-ui-rn/src/native/connectors/screens/PinLoginScreenConnector.js
+++ b/packages/edge-login-ui-rn/src/native/connectors/screens/PinLoginScreenConnector.js
@@ -14,7 +14,9 @@ export const mapStateToProps = (state: State) => {
     previousUsers: state.previousUsers.userList,
     usersWithPin: state.previousUsers.usersWithPinList,
     workflow: state.workflow,
-    showModal: state.workflow.showModal
+    showModal: state.workflow.showModal,
+    isTouchIdDisabled:
+      state.login.isLoggingInWithPin || state.login.loginSuccess
   }
 }
 

--- a/packages/edge-login-ui-rn/src/native/styles/screens/LoginPasswordScreenStyle.js
+++ b/packages/edge-login-ui-rn/src/native/styles/screens/LoginPasswordScreenStyle.js
@@ -1,8 +1,8 @@
 // @flow
 
 import * as Constants from '../../../common/constants/'
-import * as Styles from '../'
 import { scale } from '../../../common/util'
+import * as Styles from '../'
 
 const LoginPasswordScreenStyle = {
   container: Styles.ScreenStyle,

--- a/packages/edge-login-ui-rn/src/native/styles/screens/PinLoginScreenStyle.js
+++ b/packages/edge-login-ui-rn/src/native/styles/screens/PinLoginScreenStyle.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as Constants from '../../../common/constants/'
-import { scale, hs, vs } from '../../../common/util'
+import { hs, scale, vs } from '../../../common/util'
 import * as Styles from '../'
 
 const PinLoginScreenStyle = {


### PR DESCRIPTION
The purpose of this task is to disable touchID once the account has logged in to prevent touchID modal pop up once the app has been entered (logged in).

Asana Task: https://app.asana.com/0/361770107085503/476385730387081/f