### PR TITLE
Avoid deprecated type names

### DIFF
--- a/packages/edge-login-ui-rn/src/common/actions/CreateAccountActions.js
+++ b/packages/edge-login-ui-rn/src/common/actions/CreateAccountActions.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { AbcAccount } from 'edge-core-js'
+import type { EdgeAccount } from 'edge-core-js'
 import { sprintf } from 'sprintf-js'
 import passwordCheck from 'zxcvbn'
 
@@ -185,7 +185,7 @@ export function createUser (data: Object) {
     }, 300)
   }
 }
-export function agreeToConditions (account: AbcAccount) {
+export function agreeToConditions (account: EdgeAccount) {
   return (dispatch: Dispatch, getState: GetState, imports: Imports) => {
     const { callback, folder } = imports
     // write to disklet

--- a/packages/edge-login-ui-rn/src/native/components/exportAPIComponents/ChangePasswordScreen.js
+++ b/packages/edge-login-ui-rn/src/native/components/exportAPIComponents/ChangePasswordScreen.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { makeReactNativeFolder } from 'disklet'
-import type { AbcAccount, AbcContext } from 'edge-core-js'
+import type { EdgeAccount, EdgeContext } from 'edge-core-js'
 import React, { Component } from 'react'
 import { Provider } from 'react-redux'
 import type { Store } from 'redux'
@@ -14,8 +14,8 @@ import ChangePasswordAppConnector from '../../connectors/ChangePasswordAppConnec
 import * as Styles from '../../styles'
 
 type Props = {
-  account: AbcAccount,
-  context: AbcContext,
+  account: EdgeAccount,
+  context: EdgeContext,
   showHeader: boolean,
   onComplete(): void,
   onCancel(): void

--- a/packages/edge-login-ui-rn/src/native/components/exportAPIComponents/ChangePinScreen.js
+++ b/packages/edge-login-ui-rn/src/native/components/exportAPIComponents/ChangePinScreen.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { makeReactNativeFolder } from 'disklet'
-import type { AbcAccount, AbcContext } from 'edge-core-js'
+import type { EdgeAccount, EdgeContext } from 'edge-core-js'
 import React, { Component } from 'react'
 import { Provider } from 'react-redux'
 import type { Store } from 'redux'
@@ -14,8 +14,8 @@ import ChangePinConnector from '../../connectors/ChangePinConnector'
 import * as Styles from '../../styles'
 
 type Props = {
-  account: AbcAccount,
-  context: AbcContext,
+  account: EdgeAccount,
+  context: EdgeContext,
   showHeader: boolean,
   onComplete(): void,
   onCancel(): void

--- a/packages/edge-login-ui-rn/src/native/components/screens/newAccount/TermsAndConditionsScreenComponent.js
+++ b/packages/edge-login-ui-rn/src/native/components/screens/newAccount/TermsAndConditionsScreenComponent.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { AbcAccount } from 'edge-core-js'
+import type { EdgeAccount } from 'edge-core-js'
 import React, { Component } from 'react'
 import { Text, View } from 'react-native'
 
@@ -12,9 +12,9 @@ import SafeAreaView from '../../common/SafeAreaViewGradient.js'
 
 type Props = {
   styles: Object,
-  accountObject: AbcAccount,
+  accountObject: EdgeAccount,
   terms: Object,
-  agreeToCondition(AbcAccount): void
+  agreeToCondition(EdgeAccount): void
 }
 type State = {
   totalChecks: number

--- a/packages/edge-login-ui-rn/src/native/connectors/screens/newAccount/TermsAndConditionsScreenConnector.js
+++ b/packages/edge-login-ui-rn/src/native/connectors/screens/newAccount/TermsAndConditionsScreenConnector.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { AbcAccount } from 'edge-core-js'
+import type { EdgeAccount } from 'edge-core-js'
 import { connect } from 'react-redux'
 
 import * as actions from '../../../../common/actions/'
@@ -17,7 +17,7 @@ export const mapStateToProps = (state: State) => {
 
 export const mapDispatchToProps = (dispatch: Dispatch) => {
   return {
-    agreeToCondition: (data: AbcAccount) =>
+    agreeToCondition: (data: EdgeAccount) =>
       dispatch(actions.agreeToConditions(data))
   }
 }

--- a/packages/edge-login-ui-rn/src/native/keychain.js
+++ b/packages/edge-login-ui-rn/src/native/keychain.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { AbcAccount, AbcContext, DiskletFolder } from 'edge-core-js'
+import type { EdgeAccount, EdgeContext, DiskletFolder } from 'edge-core-js'
 import { NativeModules, Platform } from 'react-native'
 const { AbcCoreJsUi } = NativeModules
 
@@ -128,7 +128,7 @@ async function removeTouchIdUser (folder: DiskletFolder, username: string) {
 
 export async function enableTouchId (
   folder: DiskletFolder,
-  abcAccount: AbcAccount
+  abcAccount: EdgeAccount
 ) {
   const supported = await supportsTouchId()
 
@@ -143,7 +143,7 @@ export async function enableTouchId (
 
 export async function disableTouchId (
   folder: DiskletFolder,
-  abcAccount: AbcAccount
+  abcAccount: EdgeAccount
 ) {
   const supported = await supportsTouchId()
 
@@ -157,7 +157,7 @@ export async function disableTouchId (
 }
 
 export async function loginWithTouchId (
-  abcContext: AbcContext,
+  abcContext: EdgeContext,
   folder: DiskletFolder,
   username: string,
   promptString: string,

--- a/packages/edge-login-ui-rn/src/types/ReduxTypes.js
+++ b/packages/edge-login-ui-rn/src/types/ReduxTypes.js
@@ -1,9 +1,9 @@
 // @flow
 
 import type {
-  AbcAccount,
-  AbcAccountOptions,
-  AbcContext,
+  EdgeAccount,
+  EdgeAccountOptions,
+  EdgeContext,
   DiskletFolder
 } from 'edge-core-js'
 import type { Dispatch as ReduxDispatch, Store as ReduxStore } from 'redux'
@@ -35,10 +35,10 @@ export type State = {
     usernameErrorMessage: string,
     showModal: boolean,
     passwordStatus: Object,
-    accountObject: AbcAccount
+    accountObject: EdgeAccount
   },
   login: {
-    account: AbcAccount,
+    account: EdgeAccount,
     username: string,
     pin: string,
     password: string,
@@ -78,9 +78,9 @@ export type GetState = () => State
 export type Dispatch = ReduxDispatch<Action> & ThunkDispatch<Action>
 export type Imports = {
   onCancel: Function,
-  accountOptions: AbcAccountOptions,
-  accountObject?: AbcAccount,
-  context: AbcContext,
+  accountOptions: EdgeAccountOptions,
+  accountObject?: EdgeAccount,
+  context: EdgeContext,
   folder: DiskletFolder,
   onComplete: Function,
   callback: Function,


### PR DESCRIPTION
Names starting with `Abc` are old and deprecated.