### PR TITLE
Re-implement passwordRecovery form

### DIFF
--- a/packages/edge-login-ui-rn/src/native/components/screens/existingAccout/RecoverPasswordScreenComponent.js
+++ b/packages/edge-login-ui-rn/src/native/components/screens/existingAccout/RecoverPasswordScreenComponent.js
@@ -423,6 +423,16 @@ export default class PasswordRecovery extends Component<Props, State> {
         <Text style={styles.staticModalText}>
           {s.strings.recovery_instructions_complete}
         </Text>
+        <FormField
+          style={styles.inputModal}
+          onChangeText={this.updateEmail.bind(this)}
+          value={this.state.emailAddress}
+          label={s.strings.email_address}
+          error={''}
+          returnKeyType={'go'}
+          forceFocus
+          onSubmitEditing={this.openEmailApp}
+        />
       </View>
     )
     if (this.props.showEmailDialog) {


### PR DESCRIPTION
The purpose of this task is to re-enable the email form input on the Password Recovery Questions modal.

Asana Task: https://app.asana.com/0/361770107085503/877658538544700/f