### PR TITLE
Adjust height of PIN field on create account slightly

### DIFF
--- a/packages/edge-login-ui-rn/src/native/styles/screens/SetAccountPinScreenStyle.js
+++ b/packages/edge-login-ui-rn/src/native/styles/screens/SetAccountPinScreenStyle.js
@@ -43,7 +43,7 @@ const SetAccountPinScreenStyle = {
     ...Styles.FourDotInputDarkScaledStyle,
     container: {
       ...Styles.FourDotInputDarkScaledStyle.container,
-      height: scale(110)
+      height: scale(120)
     }
   },
   nextButton: {


### PR DESCRIPTION
 Adjust height of PIN field on create account slightly to avoid cutting off text on Android