### PR TITLE
Adjust font size of the CANCEL button on the Password Recovery screen

### DIFF
--- a/packages/edge-login-ui-rn/src/common/styles/common/HeaderStyles.js
+++ b/packages/edge-login-ui-rn/src/common/styles/common/HeaderStyles.js
@@ -27,7 +27,7 @@ const HeaderContainerStyle = {
     },
     sideText: {
       color: Constants.WHITE,
-      fontSize: scale(18)
+      fontSize: scale(14)
     },
     icon: {
       color: Constants.WHITE,


### PR DESCRIPTION
Slight font size adjustment to prevent the CANCEL text from cutting off behind the title of the screen