### PR TITLE
fix error message to only show wait when needed

### DIFF
--- a/packages/edge-login-ui-rn/src/native/connectors/abSpecific/FourDigitInputConnector.js
+++ b/packages/edge-login-ui-rn/src/native/connectors/abSpecific/FourDigitInputConnector.js
@@ -12,11 +12,11 @@ import { FourDigitInputComponent } from '../../components/abSpecific/'
 export const mapStateToProps = (state: State) => {
   const wait = state.login.wait
   const error =
-    wait < 1
-      ? state.login.errorMessage
-      : state.login.errorMessage +
+    wait && wait > 0
+      ? state.login.errorMessage +
         ': ' +
         sprintf(s.strings.account_locked_for, wait)
+      : state.login.errorMessage
   return {
     pin: state.login.pin,
     username: state.login.username,


### PR DESCRIPTION
error was showing up if wait was undefined.. now will only add if a number and > 0
Asana Task. 
Only lock the user out on `PasswordError` events
https://app.asana.com/0/361770107085503/873374534993723