### PR TITLE
Fix scaling on mobile Safari.

### DIFF
--- a/packages/edge-login-ui-web/src/demo/index.html
+++ b/packages/edge-login-ui-web/src/demo/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <meta charset="utf8" />
+  <meta charset="utf8" name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Edge Login Demo</title>
   <link href="./style/index.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
Add width and scale to <meta> tag