### PR TITLE
Fix Static Modal offset to be dependent to screen width so to scale properly with every device

### DIFF
--- a/packages/edge-login-ui-rn/src/common/styles/common/ModalStyle.js
+++ b/packages/edge-login-ui-rn/src/common/styles/common/ModalStyle.js
@@ -6,12 +6,13 @@ import * as Constants from '../../constants/'
 import { scale } from '../../util/scaling.js'
 import * as Styles from '../'
 
-const OFFSET_HACK = scale(-19)
-
 const screenDimensions = {
   height: Dimensions.get('window').height,
   width: Dimensions.get('window').width
 }
+
+const OFFSET_HACK = -(screenDimensions.width / 20)
+
 const FullScreenModalStyle = {
   container: {
     margin: 0,


### PR DESCRIPTION
task: iPad Password Recovery has a gray clear background that is uneven (see screens)

