### PR TITLE
Fix some typo, remove code that removes polling on pin login screen.

### DIFF
--- a/packages/edge-login-ui-react/src/modules/Login/LoginWithPin/LoginWithPin.js
+++ b/packages/edge-login-ui-react/src/modules/Login/LoginWithPin/LoginWithPin.js
@@ -17,11 +17,6 @@ import Mobile from './LoginWithPin.mobile.js'
 import Desktop from './LoginWithPin.web.js'
 
 class LoginWithPin extends Component {
-  componentWillReceiveProps (nextProps) {
-    if (nextProps.edgeObject) {
-      return nextProps.edgeObject.cancelRequest()
-    }
-  }
   handleSubmit = () => {
     const callback = (error, account) => {
       this.props.dispatch(loginPIN(''))

--- a/packages/edge-login-ui-react/src/modules/Login/LoginWithPin/LoginWithPin.mobile.js
+++ b/packages/edge-login-ui-react/src/modules/Login/LoginWithPin/LoginWithPin.mobile.js
@@ -41,7 +41,7 @@ export default ({
             autoFocus
             type="number"
             pattern="[0-9]*"
-            inputmode="numeric"
+            inputMode="numeric"
             name="password"
             ref={refPin}
             className={styles.input}

--- a/packages/edge-login-ui-react/src/modules/Login/LoginWithPin/LoginWithPin.web.js
+++ b/packages/edge-login-ui-react/src/modules/Login/LoginWithPin/LoginWithPin.web.js
@@ -41,7 +41,7 @@ export default ({
             autoFocus
             type="number"
             pattern="[0-9]*"
-            inputmode="numeric"
+            inputMode="numeric"
             name="password"
             ref={refPin}
             className={styles.input}


### PR DESCRIPTION
Task:Edge Login - Nothing happens after scanning the QR Code to login

Back then the mounting of QR code is directly attached to the QR code component. The code below is responsible to cancelRequest the QR code polling when user go to the Login W/ PIN screen. Now that the whole Login screen is mounting the qr code polling. The cancelRequest on Login with pin needs to be remove because Login w/ pin is part of the Login component.