### PR TITLE
Refactor Login UI bugs and features

### DIFF
--- a/packages/edge-login-ui-rn/src/native/components/abSpecific/PinKeypad.js
+++ b/packages/edge-login-ui-rn/src/native/components/abSpecific/PinKeypad.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { Component } from 'react'
-import { Text, TouchableOpacity, View } from 'react-native'
+import { Text, TouchableWithoutFeedback, View } from 'react-native'
 
 import * as Constants from '../../../common/constants'
 import { Icon } from '../common'
@@ -30,94 +30,115 @@ class PinKeypad extends Component<Props> {
     return (
       <View style={style.keypadContainer}>
         <View style={style.keypadRow}>
-          <TouchableOpacity
+          <TouchableWithoutFeedback
             style={style.keypadColumn}
             onPress={() => this.changePin('1')}
             disabled={wait}
           >
-            <Text style={style.keypadKeys}>1</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
+            <View style={style.keypadColumn}>
+              <Text style={style.keypadKeys}>1</Text>
+            </View>
+          </TouchableWithoutFeedback>
+          <TouchableWithoutFeedback
             style={style.keypadColumn}
             onPress={() => this.changePin('2')}
             disabled={wait}
           >
-            <Text style={style.keypadKeys}>2</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
+            <View style={style.keypadColumn}>
+              <Text style={style.keypadKeys}>2</Text>
+            </View>
+          </TouchableWithoutFeedback>
+          <TouchableWithoutFeedback
             style={style.keypadColumn}
             onPress={() => this.changePin('3')}
             disabled={wait}
           >
-            <Text style={style.keypadKeys}>3</Text>
-          </TouchableOpacity>
+            <View style={style.keypadColumn}>
+              <Text style={style.keypadKeys}>3</Text>
+            </View>
+          </TouchableWithoutFeedback>
         </View>
         <View style={style.keypadRow}>
-          <TouchableOpacity
+          <TouchableWithoutFeedback
             style={style.keypadColumn}
             onPress={() => this.changePin('4')}
             disabled={wait}
           >
-            <Text style={style.keypadKeys}>4</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
+            <View style={style.keypadColumn}>
+              <Text style={style.keypadKeys}>4</Text>
+            </View>
+          </TouchableWithoutFeedback>
+          <TouchableWithoutFeedback
             style={style.keypadColumn}
             onPress={() => this.changePin('5')}
             disabled={wait}
           >
-            <Text style={style.keypadKeys}>5</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
+            <View style={style.keypadColumn}>
+              <Text style={style.keypadKeys}>5</Text>
+            </View>
+          </TouchableWithoutFeedback>
+          <TouchableWithoutFeedback
             style={style.keypadColumn}
             onPress={() => this.changePin('6')}
             disabled={wait}
           >
-            <Text style={style.keypadKeys}>6</Text>
-          </TouchableOpacity>
+            <View style={style.keypadColumn}>
+              <Text style={style.keypadKeys}>6</Text>
+            </View>
+          </TouchableWithoutFeedback>
         </View>
         <View style={style.keypadRow}>
-          <TouchableOpacity
+          <TouchableWithoutFeedback
             style={style.keypadColumn}
             onPress={() => this.changePin('7')}
             disabled={wait}
           >
-            <Text style={style.keypadKeys}>7</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
+            <View style={style.keypadColumn}>
+              <Text style={style.keypadKeys}>7</Text>
+            </View>
+          </TouchableWithoutFeedback>
+          <TouchableWithoutFeedback
             style={style.keypadColumn}
             onPress={() => this.changePin('8')}
             disabled={wait}
           >
-            <Text style={style.keypadKeys}>8</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
+            <View style={style.keypadColumn}>
+              <Text style={style.keypadKeys}>8</Text>
+            </View>
+          </TouchableWithoutFeedback>
+          <TouchableWithoutFeedback
             style={style.keypadColumn}
             onPress={() => this.changePin('9')}
             disabled={wait}
           >
-            <Text style={style.keypadKeys}>9</Text>
-          </TouchableOpacity>
+            <View style={style.keypadColumn}>
+              <Text style={style.keypadKeys}>9</Text>
+            </View>
+          </TouchableWithoutFeedback>
         </View>
         <View style={style.keypadRow}>
           <View style={style.keypadColumnBlank} />
-          <TouchableOpacity
+          <TouchableWithoutFeedback
             style={style.keypadColumn}
             onPress={() => this.changePin('0')}
             disabled={wait}
           >
-            <Text style={style.keypadKeys}>0</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={style.keypadColumnBack}
+            <View style={style.keypadColumn}>
+              <Text style={style.keypadKeys}>0</Text>
+            </View>
+          </TouchableWithoutFeedback>
+          <TouchableWithoutFeedback
             onPress={() => this.changePin('back')}
             disabled={wait}
           >
-            <Icon
-              style={style.keypadKeysBack}
-              name={Constants.BACKSPACE}
-              type={Constants.MATERIAL_ICONS}
-            />
-          </TouchableOpacity>
+            <View style={style.keypadColumnBack}>
+              <Icon
+                style={style.keypadKeysBack}
+                name={Constants.BACKSPACE}
+                type={Constants.MATERIAL_ICONS}
+              />
+            </View>
+          </TouchableWithoutFeedback>
         </View>
       </View>
     )

--- a/packages/edge-login-ui-rn/src/native/components/screens/PinLogInScreenComponent.js
+++ b/packages/edge-login-ui-rn/src/native/components/screens/PinLogInScreenComponent.js
@@ -22,6 +22,7 @@ import {
   ImageButton
 } from '../../components/common'
 import FourDigitConnector from '../../connectors/abSpecific/FourDigitConnector'
+import { getSupportedBiometryType } from '../../keychain.js'
 
 type Props = {
   styles: Object,
@@ -71,9 +72,11 @@ export default class PinLogInScreenComponent extends Component<Props, State> {
     }
   }
   componentDidMount () {
-    if (this.props.username) {
-      this.props.launchUserLoginWithTouchId({ username: this.props.username })
-    }
+    getSupportedBiometryType().then(touch => {
+      if (this.props.username && touch !== 'FaceID') {
+        this.props.launchUserLoginWithTouchId({ username: this.props.username })
+      }
+    })
   }
   relaunchTouchId = () => {
     this.props.launchUserLoginWithTouchId({ username: this.props.username })
@@ -130,7 +133,9 @@ export default class PinLogInScreenComponent extends Component<Props, State> {
           </View>
         </TouchableWithoutFeedback>
         <View style={PinLoginScreenStyle.spacer_full} />
-        <PinKeypadConnector style={PinLoginScreenStyle.keypad} />
+        {this.props.userDetails.pinEnabled && (
+          <PinKeypadConnector style={PinLoginScreenStyle.keypad} />
+        )}
       </View>
     )
   }

--- a/packages/edge-login-ui-rn/src/native/styles/components/PinKeypadStyle.js
+++ b/packages/edge-login-ui-rn/src/native/styles/components/PinKeypadStyle.js
@@ -7,7 +7,7 @@ const PinKeypadStyle = {
     width: '100%',
     height: scale(180),
     maxHeight: 300,
-    marginBottom: isIphoneX ? scale(13) : 0
+    marginBottom: isIphoneX ? scale(28) : 0
   },
   keypadRow: {
     flex: 1,
@@ -29,7 +29,8 @@ const PinKeypadStyle = {
     alignConten: 'center'
   },
   keypadColumnBlank: {
-    flex: 1
+    flex: 1,
+    margin: scale(2)
   },
   keypadKeys: {
     textAlign: 'center',
@@ -38,7 +39,7 @@ const PinKeypadStyle = {
   },
   keypadKeysBack: {
     textAlign: 'center',
-    fontSize: scale(35),
+    fontSize: scale(30),
     color: Constants.ACCENT_MINT
   }
 }


### PR DESCRIPTION
Task:
Login UI - FaceID should NOT automatically launch when app is opened
Login UI - If PIN is DISABLED, the number pad is still shown
Login UI - Number pad keyboard Back/Delete button shrink down 20%
Login UI - Prevent PIN number buttons from being highlighted
Login UI - After logging out, the Num Pad is not aligned for the number column 2, 5, 8, 0
Login UI - iPhone X needs a blank space at bottom of Num Pad - Render only in safe view area. Move num pad above to safe view area.