### PR TITLE
Auto Caps Lock input and Done button of Enter Authentication Code Modal of OTP error screen

### DIFF
--- a/packages/edge-login-ui-rn/src/native/components/common/FormField.js
+++ b/packages/edge-login-ui-rn/src/native/components/common/FormField.js
@@ -68,7 +68,7 @@ class FormField extends Component<Props, State> {
         forceFocus={this.props.forceFocus}
         onFocus={this.props.onFocus}
         onBlur={this.props.onBlur}
-        autoCapitalize={'none'}
+        autoCapitalize={this.props.autoCapitalize}
         autoCorrect={this.props.autoCorrect}
         onSubmitEditing={this.onSubmitEditing}
       />

--- a/packages/edge-login-ui-rn/src/native/components/common/Modal.js
+++ b/packages/edge-login-ui-rn/src/native/components/common/Modal.js
@@ -26,6 +26,7 @@ type Props = {
   actionLabel: string,
   cancelLabel: string,
   singleButton: boolean,
+  singleCancelButton: boolean,
   buttonTimerSeconds?: number,
   modalDismissTimerSeconds?: number,
   hideCancelX: boolean,
@@ -95,6 +96,20 @@ class MyModal extends Component<Props, State> {
             downStyle={styles.twoButtonConfig.actionButton.down}
             downTextStyle={styles.twoButtonConfig.actionButton.downText}
             onPress={this.props.action}
+          />
+        </View>
+      )
+    }
+    if (this.props.singleCancelButton) {
+      return (
+        <View style={styles.buttonsWrap}>
+          <Button
+            label={this.props.cancelLabel}
+            upStyle={styles.twoButtonConfig.cancelButton.up}
+            upTextStyle={styles.twoButtonConfig.cancelButton.upText}
+            downStyle={styles.twoButtonConfig.cancelButton.down}
+            downTextStyle={styles.twoButtonConfig.cancelButton.downText}
+            onPress={this.props.cancel}
           />
         </View>
       )

--- a/packages/edge-login-ui-rn/src/native/components/materialWrappers/Input.js
+++ b/packages/edge-login-ui-rn/src/native/components/materialWrappers/Input.js
@@ -16,7 +16,7 @@ type Props = {
   errorColor: string,
   titleTextStyle: Object,
   secureTextEntry: boolean,
-  autoCapitalize: string,
+  autoCapitalize?: string,
   autoCorrect: boolean,
   autoFocus: boolean,
   forceFocus: boolean,

--- a/packages/edge-login-ui-rn/src/native/connectors/abSpecific/OtpAuthCodeModalConnector.js
+++ b/packages/edge-login-ui-rn/src/native/connectors/abSpecific/OtpAuthCodeModalConnector.js
@@ -15,15 +15,16 @@ type OwnProps = {
 }
 
 export const mapStateToProps = (state: State, ownProps: OwnProps) => {
+  const { otpUserBackupKey } = state.login
   return {
     headerText: s.strings.otp_auth_code_header,
-    // middleText: 'Sign into your account using the device you setup 2FA with, and go to Settings > 2 Factor Authentication to find the code.',
     modalMiddleComponent: ownProps.middle,
     image: OTP_SMALL,
     actionLabel: s.strings.done,
     cancelLabel: s.strings.cancel,
     hideCancelX: true,
-    thinking: ownProps.thinking
+    thinking: ownProps.thinking,
+    singleCancelButton: !otpUserBackupKey || otpUserBackupKey.length < 16
   }
 }
 export const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => {

--- a/packages/edge-login-ui-rn/src/native/connectors/componentConnectors/OtpBackupKeyConnector.js
+++ b/packages/edge-login-ui-rn/src/native/connectors/componentConnectors/OtpBackupKeyConnector.js
@@ -21,7 +21,8 @@ export const mapStateToProps = (state: State) => {
     label: s.strings.backup_key_label,
     error,
     returnKeyType: 'next',
-    autoFocus: true
+    autoFocus: true,
+    autoCapitalize: 'characters'
   }
 }
 


### PR DESCRIPTION
task: Automatically capslock text entry for 2FA code account login
2FA - Don't allow user to tap Done until text is entered