### PR TITLE
web: Add a temporary `etherscanApiKey` field

### DIFF
--- a/packages/edge-login-ui-web/src/frame/index.js
+++ b/packages/edge-login-ui-web/src/frame/index.js
@@ -17,7 +17,12 @@ export type EdgeUiContextOptions = {
   assetsPath?: string,
   hideKeys?: boolean,
   vendorImageUrl?: string,
-  vendorName?: string
+  vendorName?: string,
+
+  // This is a temporary solution, which will be replaced at the next
+  // edge-core-js version upgrade. At that point, this will change to:
+  // plugins: { ethereum: { etherscanApiKey: string[] } }
+  etherscanApiKey?: string
 }
 
 export type EdgeUiContextEvents = {

--- a/packages/edge-login-ui-web/src/frame/root-api.js
+++ b/packages/edge-login-ui-web/src/frame/root-api.js
@@ -20,6 +20,9 @@ export function sendRoot() {
   const out: BridgeRoot = {
     async makeContext(opts: EdgeUiContextOptions): Promise<EdgeUiContext> {
       if (frameUrl.origin !== parentUrl.origin) opts.hideKeys = false
+      if (opts.etherscanApiKey != null) {
+        window.etherscanApiKey = opts.etherscanApiKey
+      }
 
       return makeUiContext(opts)
     }


### PR DESCRIPTION
The Herasoft team ran into a problem sending transactions, and since the web is using an older version of edge-core-js, we need to hack in some kind of solution.