### PR TITLE
Prevent redundant vouchers from appearing

### DIFF
--- a/packages/edge-login-ui-rn/src/components/screens/OtpErrorScreen.js
+++ b/packages/edge-login-ui-rn/src/components/screens/OtpErrorScreen.js
@@ -78,8 +78,12 @@ class OtpErrorScreenComponent extends React.Component<Props> {
 
     async function handleSubmit(otpKey: string): Promise<string | void> {
       try {
+        this.checkVoucher.stop()
         await login(otpAttempt, otpKey)
       } catch (error) {
+        // Restart the background checking if the login failed:
+        this.checkVoucher.start()
+
         // Translate known errors:
         if (error != null && error.name === 'OtpError') {
           saveOtpError(otpAttempt, error)
@@ -88,6 +92,7 @@ class OtpErrorScreenComponent extends React.Component<Props> {
         if (error != null && error.message === 'Unexpected end of data') {
           return s.strings.backup_key_incorrect
         }
+
         // Pass along unknown errors:
         throw error
       }


### PR DESCRIPTION
If the background voucher-checking task happens at the same time an OTP backup modal login, it might produce an extra voucher on the server. This will bug the user to approve their own device, which is confusing. So, pause the background voucher-checking task as long as the OTP backup modal is visible.