### PR TITLE
rn: Prepare for edge-core-js breaking changes

### DIFF
--- a/packages/edge-login-ui-rn/src/components/modals/QrCodeModal.js
+++ b/packages/edge-login-ui-rn/src/components/modals/QrCodeModal.js
@@ -79,7 +79,8 @@ class QrCodeModalComponent extends React.Component<Props, State> {
   }
 
   async prepareLobby() {
-    const { accountOptions, context } = this.props.getImports()
+    const imports: Imports = this.props.getImports()
+    const { accountOptions, context } = imports
     const out: EdgePendingEdgeLogin = await context.requestEdgeLogin({
       ...accountOptions,
       // These are no longer used in recent core versions:
@@ -102,8 +103,11 @@ class QrCodeModalComponent extends React.Component<Props, State> {
     } else {
       // Older core versions have the callbacks on the context:
       this.cleanups = [
+        // $FlowFixMe
         context.on('login', account => this.handleDone(account)),
+        // $FlowFixMe
         context.on('loginStart', ({ username }) => this.handleStart(username)),
+        // $FlowFixMe
         context.on('loginError', ({ error }) => this.handleError(error))
       ]
     }

--- a/packages/edge-login-ui-rn/src/components/publicApi/PublicOtpRepairScreen.js
+++ b/packages/edge-login-ui-rn/src/components/publicApi/PublicOtpRepairScreen.js
@@ -4,7 +4,6 @@ import { type EdgeAccount, type EdgeContext, OtpError } from 'edge-core-js'
 import * as React from 'react'
 
 import { Router } from '../navigation/Router.js'
-import { showError } from '../services/AirshipInstance.js'
 import { ReduxStore } from '../services/ReduxStore.js'
 
 type Props = {
@@ -14,44 +13,22 @@ type Props = {
   otpError: OtpError
 }
 
-export class OtpRepairScreen extends React.Component<Props> {
-  cleanups: Array<() => mixed>
+export function OtpRepairScreen(props: Props): React.Node {
+  const { account, context, onComplete, otpError } = props
 
-  componentDidMount() {
-    const { context, onComplete } = this.props
-
-    // Completed Edge login:
-    this.cleanups = [
-      context.on('login', account => {
-        onComplete()
-      }),
-      context.on('loginError', ({ error }) => {
-        showError(error)
-      })
-    ]
-  }
-
-  componentWillUnmount() {
-    for (const cleanup of this.cleanups) cleanup()
-  }
-
-  render() {
-    const { account, context, onComplete, otpError } = this.props
-
-    return (
-      <ReduxStore
-        imports={{
-          accountOptions: {},
-          context,
-          onComplete
-        }}
-        initialAction={{
-          type: 'START_OTP_REPAIR',
-          data: { account, error: otpError }
-        }}
-      >
-        <Router branding={{}} showHeader />
-      </ReduxStore>
-    )
-  }
+  return (
+    <ReduxStore
+      imports={{
+        accountOptions: {},
+        context,
+        onComplete
+      }}
+      initialAction={{
+        type: 'START_OTP_REPAIR',
+        data: { account, error: otpError }
+      }}
+    >
+      <Router branding={{}} showHeader />
+    </ReduxStore>
+  )
 }

--- a/packages/edge-login-ui-rn/src/components/screens/existingAccout/SecurityAlertsScreen.js
+++ b/packages/edge-login-ui-rn/src/components/screens/existingAccout/SecurityAlertsScreen.js
@@ -36,7 +36,7 @@ type Props = OwnProps & StateProps & DispatchProps & ThemeProps
 
 type State = {
   needsResecure: boolean,
-  otpResetDate: string | void,
+  otpResetDate: Date | void,
   pendingVouchers: EdgePendingVoucher[],
   showSkip: boolean,
   spinDeny: boolean,
@@ -55,7 +55,7 @@ export class SecurityAlertsScreenComponent extends React.Component<
     const { otpResetDate, pendingVouchers = [] } = props.account
     this.state = {
       needsResecure: props.account.recoveryLogin,
-      otpResetDate,
+      otpResetDate: otpResetDate != null ? new Date(otpResetDate) : undefined,
       pendingVouchers,
       showSkip: false,
       spinDeny: false,
@@ -67,9 +67,10 @@ export class SecurityAlertsScreenComponent extends React.Component<
   componentDidMount() {
     const { account } = this.props
     this.cleanups = [
-      account.watch('otpResetDate', otpResetDate =>
-        this.setState({ otpResetDate }, this.checkEmpty)
-      ),
+      account.watch('otpResetDate', otpResetDate => {
+        const date = otpResetDate != null ? new Date(otpResetDate) : undefined
+        this.setState({ otpResetDate: date }, this.checkEmpty)
+      }),
       account.watch('pendingVouchers', pendingVouchers =>
         this.setState({ pendingVouchers }, this.checkEmpty)
       )


### PR DESCRIPTION
The next version of edge-core-js will have breaking changes. We can easily be compatible with both 0.17 and 0.18 by using the more modern API's instead of the old deprecated API's.