### PR TITLE
rn: Close the security alerts if the list starts empty

### DIFF
--- a/packages/edge-login-ui-rn/src/components/screens/existingAccout/SecurityAlertsScreen.js
+++ b/packages/edge-login-ui-rn/src/components/screens/existingAccout/SecurityAlertsScreen.js
@@ -66,6 +66,7 @@ export class SecurityAlertsScreenComponent extends React.Component<
 
   componentDidMount() {
     const { account } = this.props
+    this.checkEmpty()
     this.cleanups = [
       account.watch('otpResetDate', otpResetDate => {
         const date = otpResetDate != null ? new Date(otpResetDate) : undefined


### PR DESCRIPTION
### Fixed
- rn: Close the security alerts screen if the list starts empty. There is a race condition that that cause this to happen, so this is a simple stop-gap solution.