### PR TITLE
Use Themed Scene components header on New Account Password screen

### DIFF
--- a/packages/edge-login-ui-rn/src/components/screens/newAccount/NewAccountPasswordScreen.tsx
+++ b/packages/edge-login-ui-rn/src/components/screens/newAccount/NewAccountPasswordScreen.tsx
@@ -11,7 +11,6 @@ import { Dispatch, RootState } from '../../../types/ReduxTypes'
 import { logEvent } from '../../../util/analytics'
 import { connect } from '../../services/ReduxStore'
 import { Theme, ThemeProps, withTheme } from '../../services/ThemeContext'
-import { BackButton } from '../../themed/BackButton'
 import { EdgeText } from '../../themed/EdgeText'
 import { EdgeTextFieldOutlined } from '../../themed/EdgeTextFieldOutlined'
 import { Fade } from '../../themed/Fade'
@@ -149,8 +148,7 @@ const NewAccountPasswordScreenComponent = ({
   }
 
   return (
-    <ThemedScene paddingRem={[0.5, 0, 0.5, 0.5]}>
-      <BackButton onPress={onBack} marginRem={[0, 0, 1, -0.5]} />
+    <ThemedScene paddingRem={[0.5, 0, 0.5, 0.5]} onBack={onBack} showHeader>
       <SimpleSceneHeader>{s.strings.create_your_account}</SimpleSceneHeader>
       {focusSecond ? (
         <KeyboardAvoidingView


### PR DESCRIPTION
Note: should fix all create account screens to use Theme Component header for it to be uniformed

![74BA0CD2-5A3E-4F13-B807-51E615646443](https://user-images.githubusercontent.com/17136567/130446477-6da044f2-5f2d-4733-ac3d-948ffa586ae4.png)
