### PR TITLE
Use Themed Scene components header on New Account PIN screen

### DIFF
--- a/packages/edge-login-ui-rn/src/components/screens/newAccount/NewAccountPinScreen.tsx
+++ b/packages/edge-login-ui-rn/src/components/screens/newAccount/NewAccountPinScreen.tsx
@@ -8,7 +8,6 @@ import { Dispatch, RootState } from '../../../types/ReduxTypes'
 import { logEvent } from '../../../util/analytics'
 import { connect } from '../../services/ReduxStore'
 import { Theme, ThemeProps, withTheme } from '../../services/ThemeContext'
-import { BackButton } from '../../themed/BackButton'
 import { DigitInput, MAX_PIN_LENGTH } from '../../themed/DigitInput'
 import { EdgeText } from '../../themed/EdgeText'
 import { Fade } from '../../themed/Fade'
@@ -54,8 +53,7 @@ const NewAccountPinScreenComponent = ({
   }
 
   return (
-    <ThemedScene paddingRem={[0.5, 0, 0.5, 0.5]}>
-      <BackButton onPress={onBack} marginRem={[0, 0, 1, -0.5]} />
+    <ThemedScene paddingRem={[0.5, 0, 0.5, 0.5]} onBack={onBack} showHeader>
       <SimpleSceneHeader>{s.strings.create_your_account}</SimpleSceneHeader>
       <ScrollView ref={scrollViewRef} style={styles.content}>
         <EdgeText


### PR DESCRIPTION
Note: should fix all create account screens to use Theme Component header for it to be uniformed

![58737028-A4C2-4AAA-A9B8-D7D920F39938](https://user-images.githubusercontent.com/17136567/130448388-a4a41ca5-abde-41b7-be48-46a93c9c3801.png)