### PR TITLE
Handle START_RESECURE action type

### DIFF
--- a/packages/edge-login-ui-rn/src/reducers/SceneReducer.ts
+++ b/packages/edge-login-ui-rn/src/reducers/SceneReducer.ts
@@ -78,6 +78,7 @@ export function scene(
       return {
         currentScene: 'RecoveryLoginScene'
       }
+    case 'START_RESECURE':
     case 'RESECURE_PASSWORD':
       return {
         currentScene: 'ResecurePasswordScene'


### PR DESCRIPTION
During the changes made for the workflow-based scene transition (PRs
caused issues with scene transitions when recovering passwords using
recovery tokens since the completion of that workflow transitions
through the START_RESECURE action type.

This change restores handling for the START_RESECURE action type.