### PR TITLE
Close the keyboard when showing the QR modal

### DIFF
--- a/packages/edge-login-ui-rn/src/components/scenes/PasswordLoginScene.tsx
+++ b/packages/edge-login-ui-rn/src/components/scenes/PasswordLoginScene.tsx
@@ -522,6 +522,7 @@ export const PasswordLoginScene = connect<StateProps, DispatchProps, OwnProps>(
       dispatch({ type: 'START_PIN_LOGIN' })
     },
     handleQrModal() {
+      Keyboard.dismiss()
       dispatch(showQrCodeModal())
     },
     async login(attempt) {


### PR DESCRIPTION
Tested on iOS.