### PR TITLE
Changed Button occurrences to MainButton

### DIFF
--- a/packages/edge-login-ui-rn/src/components/common/Header.tsx
+++ b/packages/edge-login-ui-rn/src/components/common/Header.tsx
@@ -8,8 +8,8 @@ import * as Colors from '../../constants/Colors'
 import * as Constants from '../../constants/index'
 import * as Styles from '../../styles/index'
 import { scale } from '../../util/scaling'
-import { Button } from '../common/Button'
 import { HeaderBackButton } from '../common/HeaderBackButton'
+import { MainButton } from '../themed/MainButton'
 
 interface OwnProps {
   onBack?: () => void
@@ -64,13 +64,10 @@ export class Header extends React.Component<Props> {
     if (this.props.onSkip == null) return null
 
     return (
-      <Button
+      <MainButton
         onPress={this.props.onSkip}
-        downStyle={styles.textButton.downStyle}
-        downTextStyle={styles.textButton.downTextStyle}
-        upStyle={styles.textButton.upStyle}
-        upTextStyle={styles.textButton.upTextStyle}
         label={s.strings.skip}
+        type="textOnly"
       />
     )
   }

--- a/packages/edge-login-ui-rn/src/components/scenes/LandingScene.tsx
+++ b/packages/edge-login-ui-rn/src/components/scenes/LandingScene.tsx
@@ -10,7 +10,6 @@ import { logEvent } from '../../util/analytics'
 import { scale } from '../../util/scaling'
 import { LogoImageHeader } from '../abSpecific/LogoImageHeader'
 import { BackgroundImage } from '../common/BackgroundImage'
-import { Button } from '../common/Button'
 import { HeaderParentButtons } from '../common/HeaderParentButtons'
 import { connect } from '../services/ReduxStore'
 import { MainButton } from '../themed/MainButton'
@@ -59,14 +58,11 @@ class LandingSceneComponent extends React.Component<Props> {
             />
           </View>
           <View style={styles.loginButtonBox}>
-            <Button
+            <MainButton
               testID="alreadyHaveAccountButton"
               onPress={this.props.handlePassword}
               label={s.strings.landing_already_have_account}
-              downStyle={styles.loginButton.downStyle}
-              downTextStyle={styles.loginButton.downTextStyle}
-              upStyle={styles.loginButton.upStyle}
-              upTextStyle={styles.loginButton.upTextStyle}
+              type="textOnly"
             />
           </View>
         </View>

--- a/packages/edge-login-ui-rn/src/components/scenes/RecoveryLoginScene.tsx
+++ b/packages/edge-login-ui-rn/src/components/scenes/RecoveryLoginScene.tsx
@@ -8,11 +8,11 @@ import * as Constants from '../../constants/index'
 import * as Styles from '../../styles/index'
 import { Dispatch, RootState } from '../../types/ReduxTypes'
 import { LoginAttempt } from '../../util/loginAttempt'
-import { Button } from '../common/Button'
 import { FormField } from '../common/FormField'
 import { Header } from '../common/Header'
 import SafeAreaViewGradient from '../common/SafeAreaViewGradient'
 import { connect } from '../services/ReduxStore'
+import { MainButton } from '../themed/MainButton'
 
 interface OwnProps {
   showHeader?: boolean
@@ -153,12 +153,9 @@ class RecoveryLoginSceneComponent extends React.Component<Props, State> {
             </View>
             <View style={styles.buttonContainer}>
               {this.renderError()}
-              <Button
+              <MainButton
                 onPress={this.handleSubmit}
-                downStyle={styles.submitButton.downStyle}
-                downTextStyle={styles.submitButton.downTextStyle}
-                upStyle={styles.submitButton.upStyle}
-                upTextStyle={styles.submitButton.upTextStyle}
+                type="secondary"
                 label={s.strings.submit}
               />
             </View>


### PR DESCRIPTION
The "Create Account" text issue [issue](https://app.asana.com/0/1200661683177277/1201264647824046) would have actually been fixed by @swansontec's [commit](https://github.com/EdgeApp/edge-login-ui/pull/354/commits/d4d9bf2262025bc1cb6f5ed06aaa8479734d74d3#diff-76595d2394a38476a722585ce22cfdfc7e5fcb06efa2fbd7bce9eb3f4e191314R55) in [this PR](https://github.com/EdgeApp/edge-login-ui/pull/354).

This PR changes a few more instances of `<Button>`'s to `<MainButtons>` in UI2 login scenes. 

Scenes from [existingAccount](https://github.com/EdgeApp/edge-login-ui/tree/master/packages/edge-login-ui-rn/src/components/scenes/existingAccout) with `<Button>` components weren't modified since that UI will eventually be moved to UI2. 


|  ![Simulator Screen Shot - iPhone 13 mini - 2022-05-24 at 09 43 14](https://user-images.githubusercontent.com/4023066/169939868-5f7db820-26fe-4a9f-ae82-bfb22528fece.png) |  ![Simulator Screen Shot - iPhone 13 mini - 2022-05-24 at 09 43 24](https://user-images.githubusercontent.com/4023066/169939860-3ca76f33-30d6-4a40-b18e-8c103ed6d30a.png) |
|---|---|
