### PR TITLE
Accept Branding in PasswordRecoveryScreen

### DIFF
--- a/packages/edge-login-ui-rn/src/components/publicApi/PublicChangeRecoveryScreen.tsx
+++ b/packages/edge-login-ui-rn/src/components/publicApi/PublicChangeRecoveryScreen.tsx
@@ -3,18 +3,20 @@ import * as React from 'react'
 
 import { initializeChangeRecovery } from '../../actions/PasswordRecoveryActions'
 import { useClearOnUnmount } from '../../hooks/useClearOnUnmount'
+import { Branding } from '../../types/Branding'
 import { Router } from '../navigation/Router'
 import { ReduxStore } from '../services/ReduxStore'
 
 interface Props {
   account: EdgeAccount
+  branding: Branding
   context: EdgeContext
   showHeader?: boolean
   onComplete: () => void
 }
 
 export function PasswordRecoveryScreen(props: Props): JSX.Element {
-  const { account, context, onComplete, showHeader = false } = props
+  const { account, branding, context, onComplete, showHeader = false } = props
   useClearOnUnmount()
 
   return (
@@ -26,7 +28,7 @@ export function PasswordRecoveryScreen(props: Props): JSX.Element {
       }}
       initialAction={initializeChangeRecovery(account)}
     >
-      <Router branding={{}} showHeader={showHeader} />
+      <Router branding={branding} showHeader={showHeader} />
     </ReduxStore>
   )
 }

--- a/packages/edge-login-ui-rn/src/components/publicApi/PublicOtpRepairScreen.tsx
+++ b/packages/edge-login-ui-rn/src/components/publicApi/PublicOtpRepairScreen.tsx
@@ -2,18 +2,20 @@ import { EdgeAccount, EdgeContext, OtpError } from 'edge-core-js'
 import * as React from 'react'
 
 import { useClearOnUnmount } from '../../hooks/useClearOnUnmount'
+import { Branding } from '../../types/Branding'
 import { Router } from '../navigation/Router'
 import { ReduxStore } from '../services/ReduxStore'
 
 interface Props {
   account: EdgeAccount
+  branding: Branding
   context: EdgeContext
   onComplete: () => void
   otpError: OtpError
 }
 
 export function OtpRepairScreen(props: Props): JSX.Element {
-  const { account, context, onComplete, otpError } = props
+  const { account, branding, context, onComplete, otpError } = props
   useClearOnUnmount()
 
   return (
@@ -28,7 +30,7 @@ export function OtpRepairScreen(props: Props): JSX.Element {
         data: { account, error: otpError }
       }}
     >
-      <Router branding={{}} showHeader />
+      <Router branding={branding} showHeader />
     </ReduxStore>
   )
 }


### PR DESCRIPTION
'Undefined' was being written in the recovery email because the Branding appName was not being set.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202341512055666